### PR TITLE
bug: enable compatability with offline studio

### DIFF
--- a/src/Leaderboard/Board/MemoryShard.luau
+++ b/src/Leaderboard/Board/MemoryShard.luau
@@ -13,6 +13,7 @@ local FoundInTable = Util.FoundInTable;
 local GetDaysInMonth = Util.GetDaysInMonth;
 local Sha1 = Util.Sha1;
 local FALLBACK_EXPIRY_TIMES = Util.FALLBACK_EXPIRY_TIMES;
+local OFFLINE_ENVIRONMENT = game.GameId == 0;
 -- local RECORDS_FETCING_MAP = {
 -- 	["Hourly"] = 15,
 -- 	["Daily"] = 25,
@@ -123,8 +124,22 @@ function MemoryShard.new(leaderboardType: LeaderboardType, serviceKey: string, s
 
 	for i = 1, shardCount do
 		-- Each shard is a MemoryStoreSortedMap with a unique name based on the service name and shard index
-		self._shards[i] = MemoryStoreService:GetSortedMap(serviceKey .. "_Shard" .. tostring(i));
-		self._logger:Log(1, `Created MemoryStoreSortedMap for _Shared{tostring(i)}`);
+
+		if OFFLINE_ENVIRONMENT then
+			continue
+		end
+
+		local success, response = pcall(function()
+			return MemoryStoreService:GetSortedMap(serviceKey .. "_Shard" .. tostring(i))
+		end)
+
+		if success then
+			self._logger:Log(1, `Created MemoryStoreSortedMap for _Shared{tostring(i)}`);
+		else
+			self._logger:Log(1, `Failed to create MemoryStoreSortedMap for _Shared{tostring(i)}: {response}`);
+		end
+
+		self._shards[i] = success and response or nil;
 	end;
 
 	return self;
@@ -217,6 +232,10 @@ function MemoryShard:_getAsync(userId)
 	local Shard = self._shards[ShardKey] or self._shards[1];
 	return Promise.new(function(resolve, reject)
 		local success, result = pcall(function()
+			if not Shard then
+				return
+			end
+
 			return Shard:GetAsync(userId);
 		end);
 		if (not success) then
@@ -241,6 +260,10 @@ function MemoryShard:_setAsync(userId, value, expiry, sortKey)
 	local Shard = self._shards[ShardKey] or self._shards[1];
 	return Promise.new(function(resolve, reject)
 		local success, result = pcall(function()
+			if not Shard then
+				return
+			end
+
 			return Shard:SetAsync(userId, value, expiry, sortKey);
 		end);
 		if (not success) then
@@ -264,6 +287,10 @@ function MemoryShard:_updateAsync(userId, transformer, expiry)
 	local Shard = self._shards[ShardKey] or self._shards[1];
 	return Promise.new(function(resolve, reject)
 		local success, result = pcall(function()
+			if not Shard then
+				return
+			end
+
 			return Shard:UpdateAsync(userId, transformer, expiry);
 		end);
 		if (not success) then

--- a/src/Leaderboard/Board/init.luau
+++ b/src/Leaderboard/Board/init.luau
@@ -19,6 +19,7 @@ local Cancel = task.cancel;
 local Spawn = task.spawn;
 
 -- Constants
+local OFFLINE_ENVIRONMENT = game.GameId == 0;
 local SHARD_COUNTS = { -- Feel free to change these based on how many MAU your game does have
 	["Hourly"] = 1,
 	["Daily"] = 1,
@@ -44,14 +45,14 @@ export type Board = typeof(setmetatable({} :: BoardArguments, {} :: Object));
 	@interface BoardArguments
 	@field _serviceKey string
 	@field _storeUsing string
-	@field _store MemoryStoreSortedMap | OrderedDataStore | MemoryShard
+	@field _store (MemoryStoreSortedMap | OrderedDataStore | MemoryShard)?
 	@field _threads {thread}
 ]=]
 export type BoardArguments = {
 	_type: LeaderboardType,
 	_serviceKey: string,
 	_storeUsing: string,
-	_store: MemoryStoreSortedMap | OrderedDataStore | MemoryShard,
+	_store: (MemoryStoreSortedMap | OrderedDataStore | MemoryShard)?,
 	_threads: {thread},
 	_logger: Logger.Logger?,
 }
@@ -129,7 +130,7 @@ local function GetCurrentId(leaderboardType: string)
 	return leaderboardType == "Hourly" and CurrentHour or leaderboardType == "Daily" and CurrentDay or leaderboardType == "Weekly" and CurrentWeek or leaderboardType == "Monthly" and CurrentMonth or leaderboardType == "Yearly" and CurrentYear or "AllTime" and "AllTime";
 end
 
-local function ConstructStore(serviceKey: string, leaderboardType: LeaderboardType, rollingExpiry: number?): (string, MemoryStoreSortedMap | OrderedDataStore | MemoryShard)
+local function ConstructStore(serviceKey: string, leaderboardType: LeaderboardType, rollingExpiry: number?): (string, (MemoryStoreSortedMap | OrderedDataStore | MemoryShard)?)
 	-- print(rollingExpiry);
 	-- if (leaderboardType == "Hourly" or leaderboardType == "Daily" or leaderboardType == "Weekly" or leaderboardType == "Monthly" or leaderboardType == "Yearly") then
 	-- 	return "OrderedDataStore", DataStoreService:GetOrderedDataStore(`{GetCurrentId(leaderboardType)}-{serviceKey}`);
@@ -141,6 +142,10 @@ local function ConstructStore(serviceKey: string, leaderboardType: LeaderboardTy
 		local ShardCount = rollingExpiry and ShardCalculation(rollingExpiry) or SHARD_COUNTS[leaderboardType];
 		return "MemoryStore", MemoryShard.new(leaderboardType, serviceKey, ShardCount, rollingExpiry);
 	end;
+
+	if OFFLINE_ENVIRONMENT then
+		return "OrderedDataStore", {} :: any
+	end
 
 	return "OrderedDataStore", DataStoreService:GetOrderedDataStore(serviceKey);
 end
@@ -198,6 +203,10 @@ function Board:Get(amount, sortDirection)
 	sortDirection = sortDirection or "Descending";
 
 	local function RetrieveTopData()
+		if OFFLINE_ENVIRONMENT then
+			return {} :: { TopData }
+		end
+
 		if (self._storeType == "MemoryStore") then
 			local Result = self._store:Get(amount, sortDirection):awaitValue();
 			local Promises = {};
@@ -265,6 +274,10 @@ function Board:Update(userId, value)
 	-- Using an actual DataStore, we need to set the data
 	return Promise.new(function(resolve, reject)
 		local Success, Result = pcall(function()
+			if OFFLINE_ENVIRONMENT then
+				return
+			end
+
 			return self._store:UpdateAsync(userId, function(oldValue)
 				oldValue = oldValue and Compression.Decompress(oldValue) or 0;
 				local transformedValue = (type(value) == "function") and value(oldValue) or value;


### PR DESCRIPTION
Hey'o, I tried to use this module in a game of mine that is fully rojo managed, and I ran into a few errors to-do with the Roblox MemoryStore/DataStore APIs breaking when attempting to do anything in an Offline environment.

This PR aims to fix those errors, where if this module is required, or depended upon during an offline environment it silently errors and doesn't break the code that's calling the relevant APIs.

---

It would also be cool if this had official wally support, but if thats not on the agenda then i'm happy to push my own changes to wally so I can continue to use this resource.. :sweat_smile: 